### PR TITLE
Enable TLS by default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,4 +31,5 @@ end
 
 node.default['hashicorp-vault']['config']['backend_type'] = 'consul'
 node.default['hashicorp-vault']['config']['bag_item'] = 'consul'
+node.default['hashicorp-vault']['config']['tls_disable'] = false
 include_recipe 'hashicorp-vault::default'


### PR DESCRIPTION
TLS is not currently enabled even though a certificate and key are placed on disk by the recipe.
